### PR TITLE
Adding REST Feathers clients for Fetch, jQuery, Request and Superagent

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,12 +19,14 @@
     "smarttabs": true,
     "white": false,
     "node": true,
+    "browser": true,
     "globals": {
         "it": true,
         "describe": true,
         "before": true,
         "beforeEach": true,
         "after": true,
-        "afterEach": true
+        "afterEach": true,
+        "jQuery": true
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## About
 
-This provider exposes [Feathers](http://feathersjs.com) services through a RESTful API using [Express](http://expressjs.com). It can be used with Feathers 1.x and 2.x.
+This provider exposes [Feathers](http://feathersjs.com) services through a RESTful API using [Express](http://expressjs.com) that can be used with Feathers 1.x and 2.x as well as client support for Fetch, jQuery, Request and Superagent.
 
 __Note:__ For the full API documentation go to [feathersjs.com/docs/providers.html](http://feathersjs.com/docs/providers.html).
 
@@ -38,6 +38,27 @@ app.use('/:app/todos', {
     });
   }
 });
+```
+
+## Client use
+
+```js
+import feathers from 'feathers/client';
+import rest from 'feathers-rest/client';
+
+import jQuery from 'jquery';
+import fetch from 'node-fetch';
+import request from 'request';
+import superagent from 'superagent';
+
+const app = feathers()
+  .configure(rest('http://baseUrl').jquery(jQuery))
+  // or
+  .configure(rest('http://baseUrl').fetch(fetch))
+  // or
+  .configure(rest('http://baseUrl').request(request))
+  // or
+  .configure(rest('http://baseUrl').superagent(superagent))
 ```
 
 ## Changelog

--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/client');

--- a/package.json
+++ b/package.json
@@ -34,16 +34,20 @@
     "compile": "rm -rf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
-    "mocha": "mocha test/ --compilers js:babel-core/register",
+    "mocha": "mocha test/ --compilers js:babel-core/register --recursive",
     "test": "npm run compile && npm run jshint && npm run mocha"
   },
   "directories": {
     "lib": "lib"
   },
+  "browser": {
+    "./lib/index": "./lib/client/index"
+  },
   "dependencies": {
     "debug": "^2.2.0",
+    "feathers-commons": "^0.5.0",
     "feathers-errors": "^1.1.5",
-    "feathers-commons": "^0.3.1"
+    "qs": "^6.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",
@@ -52,9 +56,13 @@
     "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "body-parser": "^1.14.2",
-    "feathers": "^1.3.0",
+    "feathers": "^2.0.0-pre.1",
+    "feathers-memory": "^0.5.1",
+    "jsdom": "^6.5.1",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
-    "request": "^2.67.0"
+    "node-fetch": "^1.3.3",
+    "request": "^2.67.0",
+    "superagent": "^1.6.1"
   }
 }

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -1,0 +1,72 @@
+import query from 'qs';
+import { stripSlashes } from 'feathers-commons';
+
+export default class Base {
+  constructor(settings) {
+    this.name = stripSlashes(settings.name);
+    this.options = settings.options;
+    this.connection = settings.connection;
+    this.base = `${settings.base}/${this.name}`;
+  }
+
+  makeUrl(params, id) {
+    let url = this.base;
+
+    if (typeof id !== 'undefined') {
+      url += `/${id}`;
+    }
+
+    if(Object.keys(params).length !== 0) {
+      const queryString = query.stringify(params);
+
+      url += `?${queryString}`;
+    }
+
+    return url;
+  }
+
+  find(params) {
+    return this.request({
+      url: this.makeUrl(params),
+      method: 'GET'
+    });
+  }
+
+  get(id, params) {
+    return this.request({
+      url: this.makeUrl(params, id),
+      method: 'GET'
+    });
+  }
+
+  create(body, params) {
+    return this.request({
+      url: this.makeUrl(params),
+      body,
+      method: 'POST'
+    });
+  }
+
+  update(id, body, params) {
+    return this.request({
+      url: this.makeUrl(params, id),
+      body,
+      method: 'PUT'
+    });
+  }
+
+  patch(id, body, params) {
+    return this.request({
+      url: this.makeUrl(params, id),
+      body,
+      method: 'PATCH'
+    });
+  }
+
+  remove(id, params) {
+    return this.request({
+      url: this.makeUrl(params, id),
+      method: 'DELETE'
+    });
+  }
+}

--- a/src/client/fetch.js
+++ b/src/client/fetch.js
@@ -1,0 +1,23 @@
+import Base from './base';
+
+export default class Service extends Base {
+  request(options) {
+    let fetchOptions = Object.assign({}, {
+      method: options.method,
+      headers: {
+        'Accept': 'application/json'
+      }
+    }, options.fetch);
+
+    return new Promise((resolve, reject) => {
+      if (options.body) {
+        fetchOptions.body = JSON.stringify(options.body);
+        fetchOptions.headers['Content-Type'] = 'application/json';
+      }
+
+      this.connection(options.url, fetchOptions)
+        .then(response => response.json())
+        .then(resolve).catch(reject);
+    });
+  }
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,0 +1,33 @@
+import jQuery from './jquery';
+import Superagent from './superagent';
+import Request from './request';
+import Fetch from './fetch';
+
+const transports = {
+  jquery: jQuery,
+  superagent: Superagent,
+  request: Request,
+  fetch: Fetch
+};
+
+export default function(base = '') {
+  const result = {};
+
+  Object.keys(transports).forEach(key => {
+    const Service = transports[key];
+
+    result[key] = function(connection, options = {}) {
+      if(!connection) {
+        throw new Error(`${key} has to be provided to feathers-rest`);
+      }
+
+      return function() {
+        this.defaultService = function(name) {
+          return new Service({ base, name, connection, options });
+        };
+      };
+    };
+  });
+
+  return result;
+}

--- a/src/client/jquery.js
+++ b/src/client/jquery.js
@@ -1,0 +1,25 @@
+import Base from './base';
+
+export default class Service extends Base {
+  request(options) {
+    let opts = Object.assign({
+      dataType: options.type || 'json'
+    }, options);
+
+    if(options.body) {
+      opts.data = JSON.stringify(options.body);
+      opts.contentType = 'application/json';
+    }
+
+    delete opts.type;
+    delete opts.body;
+    
+    return new Promise((resolve, reject) => {
+      this.connection.ajax(opts).then(resolve, xhr => {
+        let error = new Error(xhr.responseText);
+        error.xhr = xhr;
+        reject(error);
+      });
+    });
+  }
+}

--- a/src/client/request.js
+++ b/src/client/request.js
@@ -1,0 +1,21 @@
+import Base from './base';
+
+export default class Service extends Base {
+  request(options) {
+    return new Promise((resolve, reject) => {
+      this.connection(Object.assign({
+        json: true
+      }, options), function(error, res, data) {
+        if(error) {
+          return reject(error);
+        }
+
+        if(!error && res.statusCode >= 400) {
+          return reject(new Error(data));
+        }
+
+        resolve(data);
+      });
+    });
+  }
+}

--- a/src/client/superagent.js
+++ b/src/client/superagent.js
@@ -1,0 +1,22 @@
+import Base from './base';
+
+export default class Service extends Base {
+  request(options) {
+    const superagent = this.connection(options.method, options.url)
+      .type(options.type || 'json');
+
+    return new Promise((resolve, reject) => {
+      if(options.body) {
+        superagent.send(options.body);
+      }
+
+      superagent.end(function(error, res) {
+        if(error) {
+          return reject(error);
+        }
+
+        resolve(res && res.body);
+      });
+    });
+  }
+}

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -4,7 +4,7 @@ import { hooks } from 'feathers-commons';
 
 const debug = makeDebug('feathers:rest');
 const hookObject = hooks.hookObject;
-const status = {
+const statusCodes = {
   created: 201,
   noContent: 204,
   methodNotAllowed: 405
@@ -17,7 +17,7 @@ function getHandler (method, getArgs, service) {
     // Check if the method exists on the service at all. Send 405 (Method not allowed) if not
     if (typeof service[method] !== 'function') {
       debug(`Method '${method}' not allowed on '${req.url}'`);
-      res.status(status.methodNotAllowed);
+      res.status(statusCodes.methodNotAllowed);
       return next(new errors.MethodNotAllowed(`Method \`${method}\` is not supported by this endpoint.`));
     }
 
@@ -42,9 +42,9 @@ function getHandler (method, getArgs, service) {
 
       if(!data) {
         debug(`No content returned for '${req.url}'`);
-        res.status(status.noContent);
+        res.status(statusCodes.noContent);
       } else if(method === 'create') {
-        res.status(status.created);
+        res.status(statusCodes.created);
       }
 
       return next();

--- a/test/client/fetch.test.js
+++ b/test/client/fetch.test.js
@@ -1,0 +1,22 @@
+import fetch from 'node-fetch';
+import feathers from 'feathers/client';
+import baseTests from 'feathers-commons/lib/test/client';
+
+import server from './server';
+import rest from '../../client';
+
+describe('fetch REST connector', function() {
+  const setup = rest('http://localhost:8889').fetch(fetch);
+  const app = feathers().configure(setup);
+  const service = app.service('todos');
+
+  before(function(done) {
+    this.server = server().listen(8889, done);
+  });
+
+  after(function(done) {
+    this.server.close(done);
+  });
+
+  baseTests(service);
+});

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+
+describe('REST client tests', function() {
+  it('is built correctly', () => {
+    const init = require('../../client');
+    const transports = init();
+
+    assert.equal(typeof init, 'function');
+    assert.equal(typeof transports.jquery, 'function');
+    assert.equal(typeof transports.request, 'function');
+    assert.equal(typeof transports.superagent, 'function');
+    assert.equal(typeof transports.fetch, 'function');
+  });
+
+  it('throw errors when no connection is provided', () => {
+    const init = require('../../client');
+    const transports = init();
+
+    try {
+      transports.fetch();
+    } catch(e) {
+      assert.equal(e.message, 'fetch has to be provided to feathers-rest');
+    }
+  });
+});

--- a/test/client/jquery.test.js
+++ b/test/client/jquery.test.js
@@ -1,0 +1,34 @@
+import jsdom from 'jsdom';
+import feathers from 'feathers';
+import baseTests from 'feathers-commons/lib/test/client';
+
+import server from './server';
+import rest from '../../client';
+
+describe('jQuery REST connector', function() {
+  const setup = rest('http://localhost:7676').jquery({});
+  const app = feathers().configure(setup);
+  const service = app.service('todos');
+
+  before(function(done) {
+    this.server = server().listen(7676, function() {
+      jsdom.env({
+        html: '<html><body></body></html>',
+        scripts: [
+          'http://code.jquery.com/jquery-2.1.4.js'
+        ],
+        done: function (err, window) {
+          window.jQuery.support.cors = true;
+          service.connection = window.jQuery;
+          done();
+        }
+      });
+    });
+  });
+
+  after(function() {
+    this.server.close();
+  });
+
+  baseTests(service);
+});

--- a/test/client/request.test.js
+++ b/test/client/request.test.js
@@ -1,0 +1,22 @@
+import request from 'request';
+import feathers from 'feathers/client';
+import baseTests from 'feathers-commons/lib/test/client';
+
+import server from './server';
+import rest from '../../client';
+
+describe('node-request REST connector', function() {
+  const setup = rest('http://localhost:6777').request(request);
+  const app = feathers().configure(setup);
+  const service = app.service('todos');
+
+  before(function(done) {
+    this.server = server().listen(6777, done);
+  });
+
+  after(function(done) {
+    this.server.close(done);
+  });
+
+  baseTests(service);
+});

--- a/test/client/server.js
+++ b/test/client/server.js
@@ -1,0 +1,49 @@
+import feathers from 'feathers';
+import bodyParser from 'body-parser';
+import memory from 'feathers-memory';
+import rest from '../../src';
+
+Object.defineProperty(Error.prototype, 'toJSON', {
+  value: function () {
+    var alt = {};
+
+    Object.getOwnPropertyNames(this).forEach(function (key) {
+      alt[key] = this[key];
+    }, this);
+
+    return alt;
+  },
+  configurable: true
+});
+
+module.exports = function(configurer) {
+  // Create an in-memory CRUD service for our Todos
+  var todoService = memory().extend({
+    get: function(id, params) {
+      if(params.query.error) {
+        throw new Error('Something went wrong');
+      }
+
+      return this._super(id, params)
+        .then(data => Object.assign({ query: params.query }, data));
+    }
+  });
+
+  var app = feathers()
+    .configure(rest())
+    // Parse HTTP bodies
+    .use(bodyParser.json())
+    .use(bodyParser.urlencoded({ extended: true }))
+    // Host the current directory (for index.html)
+    .use(feathers.static(__dirname))
+    // Host our Todos service on the /todos path
+    .use('/todos', todoService);
+
+  if(typeof configurer === 'function') {
+    configurer.call(app);
+  }
+
+  app.service('todos').create({ text: 'some todo', complete: false }, {}, function() {});
+
+  return app;
+};

--- a/test/client/superagent.test.js
+++ b/test/client/superagent.test.js
@@ -1,0 +1,22 @@
+import superagent from 'superagent';
+import feathers from 'feathers/client';
+import baseTests from 'feathers-commons/lib/test/client';
+
+import server from './server';
+import rest from '../../client';
+
+describe('Superagent REST connector', function() {
+  const setup = rest('http://localhost:8889').superagent(superagent);
+  const app = feathers().configure(setup);
+  const service = app.service('todos');
+
+  before(function(done) {
+    this.server = server().listen(8889, done);
+  });
+
+  after(function(done) {
+    this.server.close(done);
+  });
+
+  baseTests(service);
+});


### PR DESCRIPTION
This is the migrated REST library clients from `feathers-client` as standard Feathers services and a nicer configuration API.