### PR TITLE
Adds support for custom headers via params

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "feathers-commons": "^0.6.1",
+    "feathers-commons": "^0.7.0",
     "feathers-errors": "^1.1.5",
     "qs": "^6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "feathers-commons": "^0.6.0",
+    "feathers-commons": "^0.6.1",
     "feathers-errors": "^1.1.5",
     "qs": "^6.0.1"
   },

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -29,14 +29,16 @@ export default class Base {
   find(params = {}) {
     return this.request({
       url: this.makeUrl(params.query),
-      method: 'GET'
+      method: 'GET',
+      headers: Object.assign({}, params.headers)
     });
   }
 
   get(id, params = {}) {
     return this.request({
       url: this.makeUrl(params.query, id),
-      method: 'GET'
+      method: 'GET',
+      headers: Object.assign({}, params.headers)
     });
   }
 
@@ -44,7 +46,8 @@ export default class Base {
     return this.request({
       url: this.makeUrl(params.query),
       body,
-      method: 'POST'
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, params.headers)
     });
   }
 
@@ -52,7 +55,8 @@ export default class Base {
     return this.request({
       url: this.makeUrl(params.query, id),
       body,
-      method: 'PUT'
+      method: 'PUT',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, params.headers)
     });
   }
 
@@ -60,14 +64,16 @@ export default class Base {
     return this.request({
       url: this.makeUrl(params.query, id),
       body,
-      method: 'PATCH'
+      method: 'PATCH',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, params.headers)
     });
   }
 
   remove(id, params = {}) {
     return this.request({
       url: this.makeUrl(params.query, id),
-      method: 'DELETE'
+      method: 'DELETE',
+      headers: Object.assign({}, params.headers)
     });
   }
 }

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -10,6 +10,7 @@ export default class Base {
   }
 
   makeUrl(params, id) {
+    params = params || {};
     let url = this.base;
 
     if (typeof id !== 'undefined') {
@@ -25,47 +26,47 @@ export default class Base {
     return url;
   }
 
-  find(params) {
+  find(params = {}) {
     return this.request({
-      url: this.makeUrl(params),
+      url: this.makeUrl(params.query),
       method: 'GET'
     });
   }
 
-  get(id, params) {
+  get(id, params = {}) {
     return this.request({
-      url: this.makeUrl(params, id),
+      url: this.makeUrl(params.query, id),
       method: 'GET'
     });
   }
 
-  create(body, params) {
+  create(body, params = {}) {
     return this.request({
-      url: this.makeUrl(params),
+      url: this.makeUrl(params.query),
       body,
       method: 'POST'
     });
   }
 
-  update(id, body, params) {
+  update(id, body, params = {}) {
     return this.request({
-      url: this.makeUrl(params, id),
+      url: this.makeUrl(params.query, id),
       body,
       method: 'PUT'
     });
   }
 
-  patch(id, body, params) {
+  patch(id, body, params = {}) {
     return this.request({
-      url: this.makeUrl(params, id),
+      url: this.makeUrl(params.query, id),
       body,
       method: 'PATCH'
     });
   }
 
-  remove(id, params) {
+  remove(id, params = {}) {
     return this.request({
-      url: this.makeUrl(params, id),
+      url: this.makeUrl(params.query, id),
       method: 'DELETE'
     });
   }

--- a/src/client/fetch.js
+++ b/src/client/fetch.js
@@ -2,19 +2,13 @@ import Base from './base';
 
 export default class Service extends Base {
   request(options) {
-    let fetchOptions = Object.assign({}, {
-      method: options.method,
-      headers: {
-        'Accept': 'application/json'
-      }
-    }, options.fetch);
+    let fetchOptions = Object.assign({}, options);
+
+    if (options.body) {
+      fetchOptions.body = JSON.stringify(options.body);
+    }
 
     return new Promise((resolve, reject) => {
-      if (options.body) {
-        fetchOptions.body = JSON.stringify(options.body);
-        fetchOptions.headers['Content-Type'] = 'application/json';
-      }
-
       this.connection(options.url, fetchOptions)
         .then(response => response.json())
         .then(resolve).catch(reject);

--- a/src/client/superagent.js
+++ b/src/client/superagent.js
@@ -6,6 +6,8 @@ export default class Service extends Base {
       .type(options.type || 'json');
 
     return new Promise((resolve, reject) => {
+      superagent.set(options.headers);
+
       if(options.body) {
         superagent.send(options.body);
       }

--- a/test/client/fetch.test.js
+++ b/test/client/fetch.test.js
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import assert from'assert';
 import feathers from 'feathers/client';
 import baseTests from 'feathers-commons/lib/test/client';
 
@@ -19,4 +20,16 @@ describe('fetch REST connector', function() {
   });
 
   baseTests(service);
+
+  it('supports custom headers', function(done){
+    let headers = {
+      'Authorization': 'let-me-in'
+    };
+    service.get(0, { headers }).then(todo => assert.deepEqual(todo, {
+        id: 0,
+        text: 'some todo',
+        complete: false,
+        query: {}
+      })).then(done).catch(done);
+  });
 });

--- a/test/client/jquery.test.js
+++ b/test/client/jquery.test.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import jsdom from 'jsdom';
 import feathers from 'feathers';
 import baseTests from 'feathers-commons/lib/test/client';
@@ -31,4 +32,16 @@ describe('jQuery REST connector', function() {
   });
 
   baseTests(service);
+
+  it('supports custom headers', function(done){
+    let headers = {
+      'Authorization': 'let-me-in'
+    };
+    service.get(0, { headers }).then(todo => assert.deepEqual(todo, {
+        id: 0,
+        text: 'some todo',
+        complete: false,
+        query: {}
+      })).then(done).catch(done);
+  });
 });

--- a/test/client/request.test.js
+++ b/test/client/request.test.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import request from 'request';
 import feathers from 'feathers/client';
 import baseTests from 'feathers-commons/lib/test/client';
@@ -19,4 +20,16 @@ describe('node-request REST connector', function() {
   });
 
   baseTests(service);
+
+  it('supports custom headers', function(done){
+    let headers = {
+      'Authorization': 'let-me-in'
+    };
+    service.get(0, { headers }).then(todo => assert.deepEqual(todo, {
+        id: 0,
+        text: 'some todo',
+        complete: false,
+        query: {}
+      })).then(done).catch(done);
+  });
 });

--- a/test/client/superagent.test.js
+++ b/test/client/superagent.test.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import superagent from 'superagent';
 import feathers from 'feathers/client';
 import baseTests from 'feathers-commons/lib/test/client';
@@ -19,4 +20,16 @@ describe('Superagent REST connector', function() {
   });
 
   baseTests(service);
+
+  it('supports custom headers', function(done){
+    let headers = {
+      'Authorization': 'let-me-in'
+    };
+    service.get(0, { headers }).then(todo => assert.deepEqual(todo, {
+        id: 0,
+        text: 'some todo',
+        complete: false,
+        query: {}
+      })).then(done).catch(done);
+  });
 });


### PR DESCRIPTION
This allows you to set `params.headers` and those get passed to each transport appropriately. This is primarily to support auth.