### PR TITLE
Allow to instantiate a client instance

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -20,13 +20,24 @@ export default function(base = '') {
       if(!connection) {
         throw new Error(`${key} has to be provided to feathers-rest`);
       }
-
-      return function() {
-        this.rest = connection;
-        this.defaultService = function(name) {
-          return new Service({ base, name, connection, options });
-        };
+      
+      const defaultService = function(name) {
+        return new Service({ base, name, connection, options });
       };
+
+      const initialize = function() {
+        if(typeof this.defaultService === 'function') {
+          throw new Error('Only one default client provider can be configured');
+        }
+        
+        this.rest = connection;
+        this.defaultService = defaultService;
+      };
+      
+      initialize.Service = Service;
+      initialize.service = defaultService;
+      
+      return initialize;
     };
   });
 

--- a/test/client/fetch.test.js
+++ b/test/client/fetch.test.js
@@ -7,7 +7,8 @@ import server from './server';
 import rest from '../../client';
 
 describe('fetch REST connector', function() {
-  const setup = rest('http://localhost:8889').fetch(fetch);
+  const url = 'http://localhost:8889';
+  const setup = rest(url).fetch(fetch);
   const app = feathers().configure(setup);
   const service = app.service('todos');
 
@@ -21,7 +22,7 @@ describe('fetch REST connector', function() {
 
   baseTests(service);
 
-  it('supports custom headers', function(done){
+  it('supports custom headers', done => {
     let headers = {
       'Authorization': 'let-me-in'
     };
@@ -33,10 +34,24 @@ describe('fetch REST connector', function() {
       })).then(done).catch(done);
   });
 
-  it('handles errors properly', function(done){
+  it('handles errors properly', done => {
     service.get(-1, {}).catch(error => {
       assert.equal(error.code, 404);
       done();
     });
+  });
+  
+  it('can initialize a client instance', done => {
+    const init = rest(url).fetch(fetch);
+    const todos = init.service('todos');
+    
+    assert.ok(todos instanceof init.Service, 'Returned service is a client');
+    todos.find({}).then(todos => assert.deepEqual(todos, [
+      {
+        text: 'some todo',
+        complete: false,
+        id: 0
+      }
+    ])).then(() => done()).catch(done);
   });
 });

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -32,4 +32,17 @@ describe('REST client tests', function() {
     
     assert.ok(app.rest);
   });
+  
+  it('throws an error when configured twice', () => {
+    const app = feathers();
+    const rest = require('../../client');
+    app.configure(rest('http://localhost:8889').fetch(fetch));
+    
+    try {
+      app.configure(rest('http://localhost:8889').fetch(fetch));
+      assert.ok(false, 'Should never get here');
+    } catch (e) {
+      assert.equal(e.message, 'Only one default client provider can be configured');
+    }
+  });
 });

--- a/test/client/jquery.test.js
+++ b/test/client/jquery.test.js
@@ -7,7 +7,8 @@ import server from './server';
 import rest from '../../client';
 
 describe('jQuery REST connector', function() {
-  const setup = rest('http://localhost:7676').jquery({});
+  const url = 'http://localhost:7676';
+  const setup = rest(url).jquery({});
   const app = feathers().configure(setup);
   const service = app.service('todos');
 
@@ -43,5 +44,19 @@ describe('jQuery REST connector', function() {
         complete: false,
         query: {}
       })).then(done).catch(done);
+  });
+  
+  it('can initialize a client instance', done => {
+    const init = rest(url).jquery(service.connection);
+    const todos = init.service('todos');
+    
+    assert.ok(todos instanceof init.Service, 'Returned service is a client');
+    todos.find({}).then(todos => assert.deepEqual(todos, [
+      {
+        text: 'some todo',
+        complete: false,
+        id: 0
+      }
+    ])).then(() => done()).catch(done);
   });
 });

--- a/test/client/request.test.js
+++ b/test/client/request.test.js
@@ -7,7 +7,8 @@ import server from './server';
 import rest from '../../client';
 
 describe('node-request REST connector', function() {
-  const setup = rest('http://localhost:6777').request(request);
+  const url = 'http://localhost:6777';
+  const setup = rest(url).request(request);
   const app = feathers().configure(setup);
   const service = app.service('todos');
 
@@ -31,5 +32,19 @@ describe('node-request REST connector', function() {
         complete: false,
         query: {}
       })).then(done).catch(done);
+  });
+  
+  it('can initialize a client instance', done => {
+    const init = rest(url).request(request);
+    const todos = init.service('todos');
+    
+    assert.ok(todos instanceof init.Service, 'Returned service is a client');
+    todos.find({}).then(todos => assert.deepEqual(todos, [
+      {
+        text: 'some todo',
+        complete: false,
+        id: 0
+      }
+    ])).then(() => done()).catch(done);
   });
 });

--- a/test/client/superagent.test.js
+++ b/test/client/superagent.test.js
@@ -7,7 +7,8 @@ import server from './server';
 import rest from '../../client';
 
 describe('Superagent REST connector', function() {
-  const setup = rest('http://localhost:8889').superagent(superagent);
+  const url = 'http://localhost:8889';
+  const setup = rest(url).superagent(superagent);
   const app = feathers().configure(setup);
   const service = app.service('todos');
 
@@ -31,5 +32,19 @@ describe('Superagent REST connector', function() {
         complete: false,
         query: {}
       })).then(done).catch(done);
+  });
+  
+  it('can initialize a client instance', done => {
+    const init = rest(url).superagent(superagent);
+    const todos = init.service('todos');
+    
+    assert.ok(todos instanceof init.Service, 'Returned service is a client');
+    todos.find({}).then(todos => assert.deepEqual(todos, [
+      {
+        text: 'some todo',
+        complete: false,
+        id: 0
+      }
+    ])).then(() => done()).catch(done);
   });
 });


### PR DESCRIPTION
This allows to instantiate a standalone client service like:

```js
const rest = require('feathers-rest/client');

const todoService = rest(url).fetch(fetch).service('todos');
```

Also throws an error when configured twice on the client.