### PR TITLE
Fix fetch reference so that it works in the browser

### DIFF
--- a/src/client/fetch.js
+++ b/src/client/fetch.js
@@ -12,12 +12,11 @@ export default class Service extends Base {
       fetchOptions.body = JSON.stringify(options.body);
     }
 
-    return new Promise((resolve, reject) => {
-      this.connection(options.url, fetchOptions)
+    const fetch = this.connection;
+
+    return fetch(options.url, fetchOptions)
         .then(this.checkStatus)
-        .then(this.parseJSON)
-        .then(resolve).catch(reject);
-    });
+        .then(this.parseJSON);
   }
 
   checkStatus(response) {


### PR DESCRIPTION
It looks like `window.fetch` can be used without a `this` context (`const fetch = window.fetch`) but not on a different context which is what was happening when calling `this.connection`. The solution is to store  `fetch` in a variable before calling it.

Closes #54