### PR TITLE
Call `next` properly in formatter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ import wrappers from './wrappers';
 const debug = makeDebug('feathers-rest');
 
 function formatter(req, res, next) {
-  if(!res.data) {
-    next();
+  if(typeof res.data === 'undefined') {
+    return next();
   }
 
   res.format({

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import wrappers from './wrappers';
 const debug = makeDebug('feathers-rest');
 
 function formatter(req, res, next) {
-  if(typeof res.data === 'undefined') {
+  if(res.data === undefined) {
     return next();
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -311,10 +311,21 @@ describe('REST provider', function () {
           }
         });
 
+      app.use(function(req, res, next) {
+        if(typeof res.data !== 'undefined') {
+          next(new Error('Should never get here'));
+        } else {
+          next();
+        }
+      });
+
       /* jshint ignore:start */
       // Error handler
       app.use(function (error, req, res, next) {
-        assert.equal(error.message, 'Method `create` is not supported by this endpoint.');
+        if(res.statusCode < 400) {
+          res.status(500);
+        }
+
         res.json({ message: error.message });
       });
       /* jshint ignore:end */
@@ -348,7 +359,7 @@ describe('REST provider', function () {
       });
     });
 
-    it('empty response sets 204 status codes', done => {
+    it('empty response sets 204 status codes, does not run other middleware (#391)', done => {
       request('http://localhost:4780/todo', (error, response) => {
         assert.ok(response.statusCode === 204, 'Got empty status code');
 


### PR DESCRIPTION
This pull request makes sure that `next` gets called  correctly. Before, the method didn't return (so the formatter always ran and caused `Headers already sent` errors) and also didn't run properly when the data was empty (but not `undefined`).

Closes https://github.com/feathersjs/feathers/issues/391