### PR TITLE
Allow using default fetch headers for all requests

### DIFF
--- a/src/client/fetch.js
+++ b/src/client/fetch.js
@@ -6,7 +6,7 @@ export default class Service extends Base {
 
     fetchOptions.headers = Object.assign({
       Accept: 'application/json'
-    }, fetchOptions.headers);
+    }, this.options.headers, fetchOptions.headers);
 
     if (options.body) {
       fetchOptions.body = JSON.stringify(options.body);

--- a/src/client/jquery.js
+++ b/src/client/jquery.js
@@ -4,6 +4,8 @@ export default class Service extends Base {
   request(options) {
     let opts = Object.assign({
       dataType: options.type || 'json'
+    }, {
+      headers: this.options.headers || {}
     }, options);
 
     if(options.body) {


### PR DESCRIPTION
In situation where the server requires some specific headers, this allows to set them once and then use on each request
```js
const feathers = require('feathers')
const rest = require('feathers-rest/client')
const fetch = require('node-fetch')
const headers = {
   whatever: 'I need'
}
const restClient = rest('https://my.url').fetch(fetch, {headers})
const app = feathers().configure(restClient)
```