### PR TITLE
Return null for no-content responses with fetch

### DIFF
--- a/src/client/fetch.js
+++ b/src/client/fetch.js
@@ -16,7 +16,13 @@ export default class Service extends Base {
 
     return fetch(options.url, fetchOptions)
         .then(this.checkStatus)
-        .then(response => response.json());
+        .then(response => {
+          if (response.status === 204) {
+            return null;
+          }
+
+          response.json();
+        });
   }
 
   checkStatus (response) {

--- a/src/client/fetch.js
+++ b/src/client/fetch.js
@@ -21,7 +21,7 @@ export default class Service extends Base {
             return null;
           }
 
-          response.json();
+          return response.json();
         });
   }
 

--- a/test/client/fetch.test.js
+++ b/test/client/fetch.test.js
@@ -74,4 +74,11 @@ describe('fetch REST connector', function () {
       done();
     }).catch(done);
   });
+
+  it('returns null for 204 responses', done => {
+    service.remove(0, { query: { noContent: true } }).then(response => {
+      assert.strictEqual(response, null);
+      done();
+    }).catch(done);
+  });
 });

--- a/test/client/server.js
+++ b/test/client/server.js
@@ -47,11 +47,15 @@ module.exports = function (configurer) {
         .then(data => Object.assign({ query: params.query }, data));
     },
 
-    remove (id) {
+    remove (id, params) {
       if (id === null) {
         return Promise.resolve({
           id, text: 'deleted many'
         });
+      }
+
+      if (params.query.noContent) {
+        return Promise.resolve();
       }
 
       return this._super.apply(this, arguments);


### PR DESCRIPTION
Checks if the response is 204 when using fetch and return `null` body. Fixes #83 