### PR TITLE
Improve typedefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,13 @@
-declare function rest(handler:Function): Function;
+import 'express';
 
-declare namespace rest{
-  export function formatter(req:any, res:any, next:Function): void;
+declare function rest(handler?: Formatter): Function;
+
+declare interface Formatter {
+  (request: Express.Request, response: Express.Response, next?: Function);
+}
+
+declare namespace rest {
+  const formatter: Formatter;
 }
 
 export = rest;


### PR DESCRIPTION
### Summary

Aside from some type changes, this mainly makes the parameter to `rest()` optional.
Related to #101.

This PR doesn't need my PRs from other repos..