### PR TITLE
explicitly updating qs dependency due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "debug": "^2.2.0",
     "feathers-commons": "^0.8.0",
     "feathers-errors": "^2.0.1",
-    "qs": "^6.0.1"
+    "qs": "^6.4.0"
   },
   "devDependencies": {
     "axios": "^0.16.0",


### PR DESCRIPTION
### Summary

Just making the version more explicit.

See this for more details https://snyk.io/vuln/npm:qs:20170213