### PR TITLE
Add support for return data streams from services

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "debug": "^2.2.0",
     "feathers-commons": "^0.8.0",
     "feathers-errors": "^2.0.1",
+    "is-stream": "^1.1.0",
     "qs": "^6.4.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import makeDebug from 'debug';
+import isStream from 'is-stream';
 import wrappers from './wrappers';
 
 const debug = makeDebug('feathers-rest');
@@ -6,6 +7,10 @@ const debug = makeDebug('feathers-rest');
 function formatter (req, res, next) {
   if (res.data === undefined) {
     return next();
+  }
+
+  if (isStream(res.data)) {
+    return res.data.pipe(res);
   }
 
   res.format({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -508,4 +508,47 @@ describe('REST provider', function () {
       });
     });
   });
+
+  it('Allows streams to be returned from services', done => {
+    const todoService = {
+      get (id, params) {
+        return Promise.resolve({
+          id
+        });
+      }
+    };
+
+    const todoApp = feathers()
+      .configure(rest())
+      .use('/todo', todoService);
+    todoApp.set('port', 4781);
+
+    const proxyService = {
+      get (id, params) {
+        const stream = request(`http://localhost:${todoApp.get('port')}/todo/${id}`);
+        return Promise.resolve(stream);
+      }
+    };
+
+    const proxyApp = feathers()
+      .configure(rest())
+      .use('/proxy', proxyService);
+    proxyApp.set('port', 4782);
+
+    const expected = {
+      id: 'proxied-todo'
+    };
+
+    const todoServer = todoApp.listen(todoApp.get('port')).on('listening', () => {
+      const proxyServer = proxyApp.listen(proxyApp.get('port')).on('listening', () => {
+        request(`http://localhost:${proxyApp.get('port')}/proxy/${expected.id}`, (error, response, body) => {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          assert.deepEqual(expected, JSON.parse(body));
+          todoServer.close(() => {
+            proxyServer.close(done);
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Summary
- [x] Tell us about the problem your pull request is solving.
It allows the use of streams within services. This, among other things, allows you to proxy other apis and services while using the services pattern in feathers. Internally I am using this to proxy a private document generation service and stream the response through feathers to the client. This is allowing me to use the authentication, authorization and hooks in feathers to protect this other service (Note: This other service is running in a separate process using a different programing language, not just another Feathers service).
- [x] Are there any open issues that are related to this?
No, but it is a limitation that has made it very difficult to proxy other/remote apis and services while using the services pattern within Feathers.
- [x] Is this PR dependent on PRs in other repos?
No.

If so, please mention them to keep the conversations linked together.

### Other Information

I'm not sure if I have placed the additional tests in the correct location.