### PR TITLE
Add missing return-type annotation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import 'express';
 declare function rest(handler?: Formatter): Function;
 
 declare interface Formatter {
-  (request: Express.Request, response: Express.Response, next?: Function);
+  (request: Express.Request, response: Express.Response, next?: Function): void;
 }
 
 declare namespace rest {


### PR DESCRIPTION
Fixes error when compiling with --noImplicitAny flag set:
error TS7020: Call signature, which lacks return-type annotation, implicitly has an 'any' return type.

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.
error TS7020 with --noImplicitAny (TypeScript compilation)
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: