### PR TITLE
Update REST provider to Feathers v3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,22 +19,29 @@ function rest (handler = formatter) {
   return function () {
     const app = this;
 
+    if (typeof app.route !== 'function') {
+      throw new Error('feathers-rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
+    }
+
+    if (!app.version || app.version < '3.0.0') {
+      throw new Error(`feathers-rest requires an instance of a Feathers application version 3.x or later (got ${app.version})`);
+    }
+
+    app.rest = wrappers;
+
     app.use(function (req, res, next) {
       req.feathers = { provider: 'rest' };
       next();
     });
 
-    app.rest = wrappers;
-
     // Register the REST provider
-    app.providers.push(function (path, service, options) {
-      const uri = path.indexOf('/') === 0 ? path : `/${path}`;
+    app.providers.push(function (service, path, options) {
+      const uri = `/${path}`;
       const baseRoute = app.route(uri);
       const idRoute = app.route(`${uri}/:__feathersId`);
 
-      let middleware = (options || {}).middleware || {};
-      let before = middleware.before || [];
-      let after = middleware.after || [];
+      let { middleware = {} } = options;
+      let { before = [], after = [] } = middleware;
 
       if (typeof handler === 'function') {
         after = after.concat(handler);
@@ -42,9 +49,9 @@ function rest (handler = formatter) {
 
       debug(`Adding REST provider for service \`${path}\` at base route \`${uri}\``);
 
-      // GET / -> service.find(cb, params)
+      // GET / -> service.find(params)
       baseRoute.get(...before, app.rest.find(service), ...after);
-      // POST / -> service.create(data, params, cb)
+      // POST / -> service.create(data, params)
       baseRoute.post(...before, app.rest.create(service), ...after);
       // PATCH / -> service.patch(null, data, params)
       baseRoute.patch(...before, app.rest.patch(service), ...after);
@@ -53,13 +60,13 @@ function rest (handler = formatter) {
       // DELETE / -> service.remove(null, params)
       baseRoute.delete(...before, app.rest.remove(service), ...after);
 
-      // GET /:id -> service.get(id, params, cb)
+      // GET /:id -> service.get(id, params)
       idRoute.get(...before, app.rest.get(service), ...after);
-      // PUT /:id -> service.update(id, data, params, cb)
+      // PUT /:id -> service.update(id, data, params)
       idRoute.put(...before, app.rest.update(service), ...after);
-      // PATCH /:id -> service.patch(id, data, params, callback)
+      // PATCH /:id -> service.patch(id, data, params)
       idRoute.patch(...before, app.rest.patch(service), ...after);
-      // DELETE /:id -> service.remove(id, params, cb)
+      // DELETE /:id -> service.remove(id, params)
       idRoute.delete(...before, app.rest.remove(service), ...after);
     });
   };

--- a/lib/wrappers.js
+++ b/lib/wrappers.js
@@ -1,9 +1,6 @@
-const makeDebug = require('debug');
 const errors = require('feathers-errors');
-const { hooks } = require('feathers-commons');
+const debug = require('debug')('feathers:rest');
 
-const debug = makeDebug('feathers:rest');
-const hookObject = hooks.hookObject;
 const statusCodes = {
   created: 201,
   noContent: 204,
@@ -28,7 +25,7 @@ const allowedMethods = function (service) {
 // A function that returns the middleware for a given method and service
 // `getArgs` is a function that should return additional leading service arguments
 function getHandler (method, getArgs) {
-  return function (service) {
+  return service => {
     return function (req, res, next) {
       res.setHeader('Allow', allowedMethods(service).join(','));
 
@@ -40,46 +37,53 @@ function getHandler (method, getArgs) {
         return next(new errors.MethodNotAllowed(`Method \`${method}\` is not supported by this endpoint.`));
       }
 
-      let params = Object.assign({}, req.params || {});
-      delete params.__feathersId;
+      // Grab the service parameters. Use req.feathers
+      // and set the query to req.query merged with req.params
+      const params = Object.assign({
+        query: Object.assign({}, req.query, req.params)
+      }, req.feathers);
 
-      // Grab the service parameters. Use req.feathers and set the query to req.query
-      params = Object.assign({ query: req.query || {} }, params, req.feathers);
+      Object.defineProperty(params, '__returnHook', {
+        value: true
+      });
+
+      delete params.query.__feathersId;
 
       // Run the getArgs callback, if available, for additional parameters
       const args = getArgs(req, params);
 
-      // The service success callback which sets res.data or calls next() with the error
-      const callback = function (error, data) {
-        if (error) {
-          debug(`Error in REST handler: \`${error.message || error}\``);
-          res.hook = hookObject(method, 'error', args);
-          return next(error);
-        }
-
-        res.data = data;
-        res.hook = hookObject(method, 'after', args);
-
-        if (!data) {
-          debug(`No content returned for '${req.url}'`);
-          res.status(statusCodes.noContent);
-        } else if (method === 'create') {
-          res.status(statusCodes.created);
-        }
-
-        return next();
-      };
-
-      args.push(callback);
-
       debug(`REST handler calling \`${method}\` from \`${req.url}\``);
-      service[method](...args);
+
+      service[method](...args)
+        .then(hook => {
+          const data = hook.dispatch !== undefined ? hook.dispatch : hook.result;
+
+          res.data = data;
+          res.hook = hook;
+
+          if (!data) {
+            debug(`No content returned for '${req.url}'`);
+            res.status(statusCodes.noContent);
+          } else if (method === 'create') {
+            res.status(statusCodes.created);
+          }
+
+          return next();
+        })
+        .catch(hook => {
+          const { error } = hook;
+
+          debug(`Error in handler: \`${error.message}\``);
+          res.hook = hook;
+
+          return next(hook.error);
+        });
     };
   };
 }
 
 // Returns no leading parameters
-function reqNone (params) {
+function reqNone (req, params) {
   return [ params ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,47 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/express": {
-      "version": "4.0.36",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.36.tgz",
-      "integrity": "sha512-bT9q2eqH/E72AGBQKT50dh6AXzheTqigGZ1GwDiwmx7vfHff0bZOrvUWjvGpNWPNkRmX1vDF6wonG6rlpBHb1A==",
-      "dev": true,
-      "requires": {
-        "@types/express-serve-static-core": "4.0.49",
-        "@types/serve-static": "1.7.31"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.0.49",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.49.tgz",
-      "integrity": "sha512-b7mVHoURu1xaP/V6xw1sYwyv9V0EZ7euyi+sdnbnTZxEkAh4/hzPsI6Eflq+ZzHQ/Tgl7l16Jz+0oz8F46MLnA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.0.14"
-      }
-    },
-    "@types/mime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.1.tgz",
-      "integrity": "sha512-rek8twk9C58gHYqIrUlJsx8NQMhlxqHzln9Z9ODqiNgv3/s+ZwIrfr+djqzsnVM12xe9hL98iJ20lj2RvCBv6A==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-      "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w==",
-      "dev": true
-    },
-    "@types/serve-static": {
-      "version": "1.7.31",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.31.tgz",
-      "integrity": "sha1-FUVt6NmNa0z/Mb5savdJKuY/Uho=",
-      "dev": true,
-      "requires": {
-        "@types/express-serve-static-core": "4.0.49",
-        "@types/mime": "1.3.1"
-      }
-    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -184,41 +143,21 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
-    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+    "axios": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.2.4",
+        "is-buffer": "1.1.5"
+      }
     },
     "babel-code-frame": {
       "version": "6.22.0",
@@ -254,17 +193,6 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
       }
     },
     "babel-runtime": {
@@ -331,16 +259,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
     "body-parser": {
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
@@ -374,15 +292,6 @@
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         }
-      }
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
       }
     },
     "brace-expansion": {
@@ -434,12 +343,6 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
@@ -519,15 +422,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -596,15 +490,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
-      }
-    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -612,23 +497,6 @@
       "dev": true,
       "requires": {
         "es5-ext": "0.10.24"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "debug": {
@@ -706,12 +574,6 @@
         "rimraf": "2.6.1"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
     "depd": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
@@ -747,16 +609,6 @@
       "requires": {
         "esutils": "2.0.2",
         "isarray": "1.0.0"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
       }
     },
     "ee-first": {
@@ -1227,18 +1079,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
-    },
-    "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-      "dev": true
-    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -1246,25 +1086,30 @@
       "dev": true
     },
     "feathers": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/feathers/-/feathers-2.1.7.tgz",
-      "integrity": "sha512-o1PGD4EXhYN5/t2rnIW72887V1LWRcMsIhMU5IP04as4bsNvj5lkl9gBXpUX/B9mxPxKeV4hfHpkh+wDLHM+Ew==",
+      "version": "3.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/feathers/-/feathers-3.0.0-pre.1.tgz",
+      "integrity": "sha512-wvz78AVxBdCI/IGihqAjiKMsKjepFR63bnOJ1dR/oqZGK4DDTK+Szs5jsyMptJ6hXSJi6e52vPVV6v01UJfYlQ==",
       "dev": true,
       "requires": {
-        "@types/express": "4.0.36",
-        "babel-polyfill": "6.23.0",
         "debug": "2.6.8",
         "events": "1.1.1",
-        "express": "4.15.3",
-        "feathers-commons": "0.8.7",
-        "rubberduck": "1.1.1",
+        "feathers-commons": "1.0.0-pre.2",
         "uberproto": "1.2.0"
+      },
+      "dependencies": {
+        "feathers-commons": {
+          "version": "1.0.0-pre.2",
+          "resolved": "https://registry.npmjs.org/feathers-commons/-/feathers-commons-1.0.0-pre.2.tgz",
+          "integrity": "sha512-tXBfq35YuQmfQTD0+/pWO9qfdEbjMkwrO0afQvMm/r6eeDELQAU6Evmsc5Tl14pdpnttITZo0q3ZYPOC4yFvKA==",
+          "dev": true
+        }
       }
     },
     "feathers-commons": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/feathers-commons/-/feathers-commons-0.8.7.tgz",
-      "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I="
+      "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I=",
+      "dev": true
     },
     "feathers-errors": {
       "version": "2.8.2",
@@ -1272,6 +1117,17 @@
       "integrity": "sha512-+u6xr2JTah5CGPyDv5iCyMnCkloYTzjmmuT5luw8LqUdvf+sDJfWAovBE/F9or1Hs2PXTO7LoidmPHzMQlExNw==",
       "requires": {
         "debug": "2.6.8"
+      }
+    },
+    "feathers-express": {
+      "version": "1.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/feathers-express/-/feathers-express-1.0.0-pre.1.tgz",
+      "integrity": "sha512-VOdVatVwvy4+ejvPyOdA5vKTB/o5iIUfOsmspNFcTmMLpELvfcVfy3wUON9Htxf8Myc0wwN5N8OVSTWgjlcyag==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "express": "4.15.3",
+        "uberproto": "1.2.0"
       }
     },
     "feathers-memory": {
@@ -1379,28 +1235,20 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
+      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8"
+      }
+    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
-      }
     },
     "forwarded": {
       "version": "0.1.0",
@@ -1446,23 +1294,6 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
     },
     "glob": {
       "version": "7.1.2",
@@ -1539,22 +1370,6 @@
         }
       }
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
-    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -1579,24 +1394,6 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
-    },
     "http-errors": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
@@ -1607,17 +1404,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
-      }
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
       }
     },
     "iconv-lite": {
@@ -1804,12 +1590,6 @@
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -1826,12 +1606,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul": {
@@ -1971,23 +1745,10 @@
         "esprima": "4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
@@ -1998,12 +1759,6 @@
       "requires": {
         "jsonify": "0.0.0"
       }
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -2022,26 +1777,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
-        "json-schema": "0.2.3",
-        "verror": "1.3.6"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
@@ -2368,12 +2103,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2522,12 +2251,6 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-      "dev": true
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2633,12 +2356,6 @@
         "ipaddr.js": "1.3.0"
       }
     },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
-    },
     "qs": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
@@ -2717,44 +2434,6 @@
         "is-finite": "1.0.2"
       }
     },
-    "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        }
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2808,12 +2487,6 @@
       "requires": {
         "glob": "7.1.2"
       }
-    },
-    "rubberduck": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rubberduck/-/rubberduck-1.1.1.tgz",
-      "integrity": "sha1-zSzaS4ZxeBNer8mVpxOE9fdD2wI=",
-      "dev": true
     },
     "run-async": {
       "version": "0.1.0",
@@ -2933,15 +2606,6 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
@@ -2953,30 +2617,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
     },
     "standard-engine": {
       "version": "7.0.0",
@@ -3023,12 +2663,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -3125,15 +2759,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -3145,22 +2770,6 @@
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -3245,26 +2854,11 @@
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
     },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
-    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
       "dev": true
-    },
-    "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true,
-      "requires": {
-        "extsprintf": "1.0.2"
-      }
     },
     "which": {
       "version": "1.2.14",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "version": "2.0.0-pre.0",
   "homepage": "https://github.com/feathersjs/feathers-rest",
   "main": "lib/",
-  "types": [
-    "./index.d.ts",
-    "./client.d.ts"
-  ],
   "keywords": [
     "feathers",
     "feathers-plugin"
@@ -37,6 +33,7 @@
     "release:major": "npm version major && npm publish",
     "lint": "semistandard --fix",
     "mocha": "mocha --opts mocha.opts",
+    "mocha:watch": "mocha --opts mocha.opts --watch",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "test": "npm run lint && npm run coverage"
   },
@@ -48,25 +45,19 @@
   "directories": {
     "lib": "lib"
   },
-  "browser": {
-    "./lib/index": "./lib/client/index"
-  },
-  "greenkeeper": {
-    "ignore": "jsdom"
-  },
   "dependencies": {
     "debug": "^2.2.0",
-    "feathers-commons": "^0.8.0",
     "feathers-errors": "^2.0.1",
     "qs": "^6.4.0"
   },
   "devDependencies": {
+    "axios": "^0.16.2",
     "body-parser": "^1.14.2",
-    "feathers": "^2.0.0-pre.1",
+    "feathers": "^3.0.0-pre.1",
+    "feathers-express": "^1.0.0-pre.1",
     "feathers-memory": "^1.0.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.0.0",
-    "request": "^2.81.0",
     "semistandard": "^11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "axios": "^0.16.2",
     "body-parser": "^1.14.2",
     "feathers": "^3.0.0-pre.1",
+    "feathers-commons": "^0.8.7",
     "feathers-express": "^1.0.0-pre.1",
     "feathers-memory": "^1.0.0",
     "istanbul": "^1.1.0-alpha.1",

--- a/test/crud.js
+++ b/test/crud.js
@@ -1,0 +1,102 @@
+const assert = require('assert');
+const axios = require('axios');
+const { verify } = require('feathers-commons/lib/test-fixture');
+
+module.exports = function crud (description, name) {
+  describe(description, () => {
+    it('GET .find', () => {
+      return axios.get(`http://localhost:4777/${name}`)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.find(res.data);
+        });
+    });
+
+    it('GET .get', () => {
+      return axios.get('http://localhost:4777/todo/dishes')
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.get('dishes', res.data);
+        });
+    });
+
+    it('POST .create', () => {
+      let original = {
+        description: 'POST .create'
+      };
+
+      return axios.post(`http://localhost:4777/${name}`, original)
+        .then(res => {
+          assert.ok(res.status === 201, 'Got CREATED status code');
+          verify.create(original, res.data);
+        });
+    });
+
+    it('PUT .update', () => {
+      let original = {
+        description: 'PUT .update'
+      };
+
+      return axios.put('http://localhost:4777/todo/544', original)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.update(544, original, res.data);
+        });
+    });
+
+    it('PUT .update many', () => {
+      let original = {
+        description: 'PUT .update',
+        many: true
+      };
+
+      return axios.put(`http://localhost:4777/${name}`, original)
+        .then(res => {
+          const { data } = res;
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.update(null, original, data);
+        });
+    });
+
+    it('PATCH .patch', () => {
+      let original = {
+        description: 'PATCH .patch'
+      };
+
+      return axios.patch('http://localhost:4777/todo/544', original)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.patch(544, original, res.data);
+        });
+    });
+
+    it('PATCH .patch many', () => {
+      let original = {
+        description: 'PATCH .patch',
+        many: true
+      };
+
+      return axios.patch(`http://localhost:4777/${name}`, original)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.patch(null, original, res.data);
+        });
+    });
+
+    it('DELETE .remove', () => {
+      return axios.delete('http://localhost:4777/tasks/233')
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.remove(233, res.data);
+        });
+    });
+
+    it('DELETE .remove many', () => {
+      return axios.delete('http://localhost:4777/tasks')
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.remove(null, res.data);
+        });
+    });
+  });
+};


### PR DESCRIPTION
This pull request

- Updates the REST handler to Feathers v3 (move from callbacks to promises)
- Updates the tests to use Promises and Axios
- Changes route parameter mappings (e.g. service name `/user/:userId/todos`) from `params` to `params.query`